### PR TITLE
Revert "universal7885-common: sepolicy: Remove duplicate entry"

### DIFF
--- a/universal7885-common/sepolicy/vendor/device.te
+++ b/universal7885-common/sepolicy/vendor/device.te
@@ -23,6 +23,7 @@ type radio_block_device, dev_type;
 type sec_efs_block_device, dev_type;
 
 type bbd_device, dev_type;
+type bt_device, dev_type;
 type cpu_dma_device, dev_type;
 type drb_device, dev_type;
 type epic_device, dev_type;


### PR DESCRIPTION
This commit [8232344f2c45b2c754f2b129dab62256464d409f] broke sepolicy with an error of 'bt_device' being unknown.

What even was the "duplicate entry" that was removed here? 
I'm either missing something or this commit was untested and just broke things.