### PR TITLE
Disable FRP

### DIFF
--- a/universal7885-common/vendor.prop
+++ b/universal7885-common/vendor.prop
@@ -1,9 +1,9 @@
 # Use 64-bit dex2oat for better dexopt time.
 dalvik.vm.dex2oat64.enabled=true
 
-## FRP
-# Disable invocation of oem_lock
-ro.frp.pst=/dev/block/persistent
+### FRP
+## Disable invocation of oem_lock
+# ro.frp.pst=/dev/block/persistent
 
 ## OMX
 # Set csc support in OMX


### PR DESCRIPTION
Google is being strict about this so I would like it to be disabled, else people have to try login and fail connection like 5 times until they can sign in. They have freedom to skip or setup with login.