### PR TITLE
Some minimal modifications

### DIFF
--- a/a10/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/a10/overlay/frameworks/base/core/res/res/values/config.xml
@@ -33,6 +33,6 @@
                 <string ...>M -5,0 L -5,10 L 5,10 L 5,0 Z @dp</string>
          @see https://www.w3.org/TR/SVG/paths.html#PathData
          -->
-   <string translatable="false" name="config_mainBuiltInDisplayCutout">M62,0l-3.8,0l-3.9,0.2l-3.9,0.4l-4,0.8l-3.9,1.2l-3.8,1.6l-3.7,2l-3.4,2.4l-3.1,2.8l-2.9,3l-2.7,3.1l-2.6,3.1 l-2.7,2.8C12.5,28,6.2,30.3,0,30.3c-6.3,0-12.5-2.3-17.5-6.8l-2.7-2.8l-2.6-3.1l-2.7-3.1l-2.9-3l-3.2-2.8 L-35,6.2l-3.7-2l-3.8-1.6l-3.9-1.2l-4-0.8L-54.3,0.2L-58.2,0L-62,0Z @dp</string>
+   <string translatable="false" name="config_mainBuiltInDisplayCutout">M 0,0 H -32 V 31.42857142857143 H 32 V 0 H 0 Z @dp</string>
    <string translatable="false" name="config_mainBuiltInDisplayCutoutRectApproximation">@*android:string/config_mainBuiltInDisplayCutout</string>
 </resources>

--- a/universal7885-common/configs/vintf/compatibility_matrix.xml
+++ b/universal7885-common/configs/vintf/compatibility_matrix.xml
@@ -13,14 +13,6 @@
       </interface>
    </hal>
    <hal format="hidl" optional="true">
-      <name>android.frameworks.schedulerservice</name>
-      <version>1.0</version>
-      <interface>
-         <name>ISchedulingPolicyService</name>
-         <instance>default</instance>
-      </interface>
-   </hal>
-   <hal format="hidl" optional="true">
       <name>android.frameworks.sensorservice</name>
       <version>1.0</version>
       <interface>

--- a/universal7885-common/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/universal7885-common/overlay/frameworks/base/core/res/res/values/config.xml
@@ -35,9 +35,6 @@
    </string-array>
    <string name="config_radio_access_family">GSM|CDMA|EVDO|WCDMA|LTE</string>
    <fraction name="config_screenAutoBrightnessDozeScaleFactor">100.0%</fraction>
-   <string name="db_default_journal_mode" translatable="false">MEMORY</string>
-   <string name="db_default_sync_mode" translatable="false">OFF</string>
-   <string name="db_wal_sync_mode" translatable="false">OFF</string>
    <!-- Whether Hearing Aid profile is supported -->
    <bool name="config_hearing_aid_profile_supported">true</bool>
    <bool name="config_showNavigationBar">true</bool>

--- a/universal7885-common/overlay/frameworks/base/packages/SystemUI/res/values/integers.xml
+++ b/universal7885-common/overlay/frameworks/base/packages/SystemUI/res/values/integers.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2018 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate. -->
+
+<resources>
+    <!-- Maximum number of notification icons shown on the lockscreen (excluding overflow dot) -->
+    <integer name="max_notif_icons_on_lockscreen">4</integer>
+    <!-- Maximum number of notification icons shown in the status bar (excluding overflow dot) -->
+    <integer name="max_notif_static_icons">4</integer>
+</resources>

--- a/universal7885-common/system.prop
+++ b/universal7885-common/system.prop
@@ -13,6 +13,7 @@ persist.sys.binary_xml=false
 # Rendering
 debug.renderengine.backend=skiaglthreaded
 renderthread.skia.reduceopstasksplitting=true
+debug.hwui.skia_atrace_enabled=false
 
 # Blur
 ro.sf.blurs_are_expensive=1

--- a/universal7885-common/system.prop
+++ b/universal7885-common/system.prop
@@ -13,7 +13,6 @@ persist.sys.binary_xml=false
 # Rendering
 debug.renderengine.backend=skiaglthreaded
 renderthread.skia.reduceopstasksplitting=true
-ro.surface_flinger.max_frame_buffer_acquired_buffers=3
 
 # Blur
 ro.sf.blurs_are_expensive=1

--- a/universal7885-common/universal7885-common.mk
+++ b/universal7885-common/universal7885-common.mk
@@ -3,9 +3,6 @@ ifeq ($(TARGET_LOCAL_ARCH),arm64)
 $(call inherit-product, vendor/samsung/universal7885-common/universal7885-common-vendor.mk)
 endif
 
-# .apex packages
-$(call inherit-product, $(SRC_TARGET_DIR)/product/updatable_apex.mk)
-
 # Soong namespaces
 $(call inherit-product, hardware/samsung_slsi-linaro/config/config.mk)
 

--- a/universal7885-common/vendor.prop
+++ b/universal7885-common/vendor.prop
@@ -13,6 +13,7 @@ ro.vendor.cscsupported=1
 ## OpenGLES
 ro.opengles.version=196610
 ro.hardware.egl=mali
+ro.hardware.vulkan=mali
 
 ## HW Graphics
 debug.egl.hw=0

--- a/universal7885-common/vendor.prop
+++ b/universal7885-common/vendor.prop
@@ -28,6 +28,7 @@ ro.surface_flinger.set_idle_timer_ms=80
 ro.surface_flinger.set_touch_timer_ms=200
 ro.surface_flinger.set_display_power_timer_ms=1000
 ro.surface_flinger.use_content_detection_for_refresh_rate=true
+debug.sf.predict_hwc_composition_strategy=0
 ro.surface_flinger.max_frame_buffer_acquired_buffers=3
 debug.sf.disable_client_composition_cache=1
 

--- a/universal7885-common/vendor.prop
+++ b/universal7885-common/vendor.prop
@@ -22,15 +22,15 @@ debug.sf.hw=0
 ro.telephony.default_network=9,9
 
 ## Surfaceflinger
-ro.surface_flinger.max_frame_buffer_acquired_buffers=3
 debug.sf.enable_hwc_vds=0
 debug.sf.enable_advanced_sf_phase_offset=1
 ro.surface_flinger.set_idle_timer_ms=80
 ro.surface_flinger.set_touch_timer_ms=200
 ro.surface_flinger.set_display_power_timer_ms=1000
 ro.surface_flinger.use_content_detection_for_refresh_rate=true
-debug.sf.disable_client_composition_cache=1
 ro.surface_flinger.max_frame_buffer_acquired_buffers=3
+debug.sf.disable_client_composition_cache=1
+
 
 # Display
 persist.sys.sf.color_mode=0


### PR DESCRIPTION
1: Remove duplicates triple buffer props flags for surfaceflinger
2: Disable Skia Tracing for reduce debugs problems.
3: Is not necessary to explicit include updatable_apex.mk, QPR2 roms sources already include this in config.
4: Add a new notification overlay for icons: just add 4 notifications icons a limit.
5: Remove schedulerservice from compatibility matrix, is no more necessary.
6: Remove SQLite Memory optimizations, this is not necessary and is not safe.
7: Disable SurfaceFlinger composition prediction model.
8: Define mali in ro.hardware.vulkan