### PR TITLE
universal7885: move boot-image to boot

### DIFF
--- a/universal7885-common/universal7885-common.mk
+++ b/universal7885-common/universal7885-common.mk
@@ -382,7 +382,7 @@ PRODUCT_SOONG_NAMESPACES += \
 # Speed profile services and wifi-service to reduce RAM and storage
 PRODUCT_SYSTEM_SERVER_COMPILER_FILTER := speed-profile
 PRODUCT_USE_PROFILE_FOR_BOOT_IMAGE := true
-PRODUCT_DEX_PREOPT_BOOT_IMAGE_PROFILE_LOCATION := frameworks/base/config/boot-image-profile.txt
+PRODUCT_DEX_PREOPT_BOOT_IMAGE_PROFILE_LOCATION := frameworks/base/boot/boot-image-profile.txt
 
 # Task profiles
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
This fixes the following build errors:

![image](https://github.com/user-attachments/assets/bc3e3f70-5c02-4112-84eb-4e2aac53d18e)
